### PR TITLE
Muestra eventos con fechas en el futuro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - tar xvzf hugo.tar.gz
 
 script:
-  - ./hugo -d public
+  - ./hugo -F -d public
 
 deploy:
   skip_cleanup: true


### PR DESCRIPTION
Este cambio permite eventos con fechas en el futuro. Normalmente hugo no genera paginas para contenido con una fecha en el futuro. 